### PR TITLE
feat: add solana_node_is_active metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The table below describes all the metrics collected by the `solana-exporter`:
 | `solana_account_balance`                       | Solana account balances.                                                                 | `address`                     |
 | `solana_node_version`                          | Node version of solana.*                                                                 | `version`                     |
 | `solana_node_is_healthy`                       | Whether the node is healthy.*                                                            | N/A                           |
+| `solana_node_is_active`                        | Whether the node is active and participating in consensus.                              | `nodekey`                     |
 | `solana_node_num_slots_behind`                 | The number of slots that the node is behind the latest cluster confirmed slot.*          | N/A                           |
 | `solana_node_minimum_ledger_slot`              | The lowest slot that the node has information about in its ledger.*                      | N/A                           |
 | `solana_node_first_available_block`            | The slot of the lowest confirmed block that has not been purged from the node's ledger.* | N/A                           |

--- a/cmd/solana-exporter/collector.go
+++ b/cmd/solana-exporter/collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/asymmetric-research/solana-exporter/pkg/rpc"
 	"github.com/asymmetric-research/solana-exporter/pkg/slog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,6 +44,7 @@ type SolanaCollector struct {
 	NodeNumSlotsBehind      *GaugeDesc
 	NodeMinimumLedgerSlot   *GaugeDesc
 	NodeFirstAvailableBlock *GaugeDesc
+	NodeIsActive            *GaugeDesc
 }
 
 func NewSolanaCollector(client *rpc.Client, config *ExporterConfig) *SolanaCollector {
@@ -96,6 +98,11 @@ func NewSolanaCollector(client *rpc.Client, config *ExporterConfig) *SolanaColle
 			"solana_node_first_available_block",
 			"The slot of the lowest confirmed block that has not been purged from the node's ledger.",
 		),
+		NodeIsActive: NewGaugeDesc(
+			"solana_node_is_active",
+			"Whether the node is active and participating in consensus.",
+			NodekeyLabel,
+		),
 	}
 	return collector
 }
@@ -111,6 +118,7 @@ func (c *SolanaCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.NodeNumSlotsBehind.Desc
 	ch <- c.NodeMinimumLedgerSlot.Desc
 	ch <- c.NodeFirstAvailableBlock.Desc
+	ch <- c.NodeIsActive.Desc
 }
 
 func (c *SolanaCollector) collectVoteAccounts(ctx context.Context, ch chan<- prometheus.Metric) {
@@ -244,6 +252,28 @@ func (c *SolanaCollector) collectHealth(ctx context.Context, ch chan<- prometheu
 	return
 }
 
+func (c *SolanaCollector) collectNodeIdentityPubKey(ctx context.Context, ch chan<- prometheus.Metric) {
+	c.logger.Info("Collecting node identity pubkey...")
+
+	nodeIdentityPubkey, err := c.rpcClient.GetIdentity(ctx)
+	if err != nil {
+		c.logger.Errorf("failed to get node identity: %v", err)
+		ch <- c.NodeIsActive.NewInvalidMetric(err)
+		return
+	}
+
+	isActive := 0
+	for _, configuredKey := range c.config.NodeKeys {
+		if configuredKey == nodeIdentityPubkey {
+			isActive = 1
+			break
+		}
+	}
+
+	ch <- c.NodeIsActive.MustNewConstMetric(float64(isActive), nodeIdentityPubkey)
+	c.logger.Info("Node identity pubkey collected.")
+}
+
 func (c *SolanaCollector) Collect(ch chan<- prometheus.Metric) {
 	c.logger.Info("========== BEGIN COLLECTION ==========")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -255,6 +285,7 @@ func (c *SolanaCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectVoteAccounts(ctx, ch)
 	c.collectVersion(ctx, ch)
 	c.collectBalances(ctx, ch)
+	c.collectNodeIdentityPubKey(ctx, ch)
 
 	c.logger.Info("=========== END COLLECTION ===========")
 }

--- a/cmd/solana-exporter/collector_test.go
+++ b/cmd/solana-exporter/collector_test.go
@@ -4,16 +4,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/asymmetric-research/solana-exporter/pkg/rpc"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"math/rand"
 	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/asymmetric-research/solana-exporter/pkg/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 type (
@@ -235,6 +236,9 @@ func TestSolanaCollector(t *testing.T) {
 		),
 		collector.NodeVersion.makeCollectionTest(
 			NewLV(1, "v1.0.0"),
+		),
+		collector.NodeIsActive.makeCollectionTest(
+			NewLV(1),
 		),
 		collector.NodeIsHealthy.makeCollectionTest(
 			NewLV(1),

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/asymmetric-research/solana-exporter/pkg/slog"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"slices"
 	"time"
+
+	"github.com/asymmetric-research/solana-exporter/pkg/slog"
+	"go.uber.org/zap"
 )
 
 type (
@@ -258,4 +259,14 @@ func (c *Client) GetFirstAvailableBlock(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 	return resp.Result, nil
+}
+
+// GetIdentity returns the identity (node) pubkey for the current node
+// See API docs: https://solana.com/docs/rpc/http/getidentity
+func (c *Client) GetIdentity(ctx context.Context) (string, error) {
+	var resp Response[NodeIdentity]
+	if err := getResponse(ctx, c, "getIdentity", []any{}, &resp); err != nil {
+		return "", err
+	}
+	return resp.Result.Identity, nil
 }

--- a/pkg/rpc/client_test.go
+++ b/pkg/rpc/client_test.go
@@ -2,8 +2,9 @@ package rpc
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func newMethodTester(t *testing.T, method string, result any) (*MockServer, *Client) {
@@ -243,4 +244,15 @@ func TestClient_GetVoteAccounts(t *testing.T) {
 		},
 		voteAccounts,
 	)
+}
+func TestClient_GetIdentity(t *testing.T) {
+	_, client := newMethodTester(t, "getIdentity", map[string]string{
+		"identity": "random2r1F4iWqVcb8M1DbAjQuFpebkQuW2DJtestkey",
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	identity, err := client.GetIdentity(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "random2r1F4iWqVcb8M1DbAjQuFpebkQuW2DJtestkey", identity)
 }

--- a/pkg/rpc/responses.go
+++ b/pkg/rpc/responses.go
@@ -88,6 +88,10 @@ type (
 			} `json:"message"`
 		} `json:"transaction"`
 	}
+
+	NodeIdentity struct {
+		Identity string `json:"identity"`
+	}
 )
 
 func (e *RPCError) Error() string {


### PR DESCRIPTION
## Summary
feat: add solana_node_is_active metric

## Details
dd the solana_node_is_active metric based on the node keys provided.

This feature will help identify the active validator node(s), serving as the first step toward replacing solana-mission-control, the service currently in use. We implemented a similar feature in solana-mission-control a few months ago: https://github.com/andreclaro/solana-mission-control/commit/a512d7275768c11428708338d2f5b68bed45a45c

## Testing
- Added Unit tests

Tested in or testnet nodes:

- Active:
```
# HELP solana_node_is_active Whether the node is using one of the configured node (identity) keys
# TYPE solana_node_is_active gauge
solana_node_is_active{nodekey="XQTV65qyxFtpm9dDLxxnYk42getfCsEqj2nPSmGZmrm"} 1
```

Passive:
```
# HELP solana_node_is_active Whether the node is using one of the configured node (identity) keys
# TYPE solana_node_is_active gauge
solana_node_is_active{nodekey="F2451eq4fkmEAaSBQLcNeaqExf4nsUw7Hcpy35T7iWJf"} 0
```