### PR TITLE
feat: add minimum required version metric.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The table below describes all the metrics collected by the `solana-exporter`:
 | `solana_validator_fee_rewards`                 | Transaction fee rewards earned.                                                          | `nodekey`, `epoch`            |
 | `solana_validator_block_size`                  | Number of transactions per block.                                                        | `nodekey`, `transaction_type` |
 | `solana_node_block_height`                     | The current block height of the node.*                                                   | N/A                           |
+| `solana_foundation_min_required_version`        | Minimum required Solana version for the [solana foundation delegation program](https://solana.org/delegation-program)                        | `version`, `cluster`          |
 
 ***NOTE***: An `*` in the description indicates that the metric **is** tracked in `-light-mode`.
 
@@ -102,6 +103,7 @@ The table below describes the various metric labels:
 | `votekey`           | Validator vote account address.     | e.g., `CertusDeBmqN8ZawdkxK5kFGMwBXdudvWHYwtNgNhvLu` |
 | `address`          | Solana account address.             | e.g., `Certusm1sa411sMpV9FPqU5dXAYhmmhygvxJ23S6hJ24` |
 | `version`          | Solana node version.                | e.g., `v1.18.23`                                     |
+| `cluster`          | Solana cluster name.                | `mainnet-beta`, `testnet`, `devnet`                  |
 | `status`           | Whether a slot was skipped or valid | `valid`, `skipped`                                   |
 | `epoch`            | Solana epoch number.                | e.g., `663`                                          |
 | `transaction_type` | General transaction type.           | `vote`, `non_vote`                                   |

--- a/cmd/solana-exporter/main.go
+++ b/cmd/solana-exporter/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/asymmetric-research/solana-exporter/pkg/api"
 	"github.com/asymmetric-research/solana-exporter/pkg/rpc"
 	"github.com/asymmetric-research/solana-exporter/pkg/slog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,9 +27,10 @@ func main() {
 		)
 	}
 
-	client := rpc.NewRPCClient(config.RpcUrl, config.HttpTimeout)
-	collector := NewSolanaCollector(client, config)
-	slotWatcher := NewSlotWatcher(client, config)
+	rpcClient := rpc.NewRPCClient(config.RpcUrl, config.HttpTimeout)
+	apiClient := api.NewClient()
+	collector := NewSolanaCollector(rpcClient, apiClient, config)
+	slotWatcher := NewSlotWatcher(rpcClient, config)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go slotWatcher.WatchSlots(ctx)

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// CacheTimeout defines how often to refresh the minimum required version (6 hours)
+	CacheTimeout = 6 * time.Hour
+
+	// SolanaEpochStatsAPI is the base URL for the Solana validators epoch stats API
+	SolanaEpochStatsAPI = "https://api.solana.org/api/validators/epoch-stats"
+)
+
+type Client struct {
+	HttpClient http.Client
+	baseURL    string
+	cache      struct {
+		version   string
+		lastCheck time.Time
+	}
+	mu sync.RWMutex
+	// How often to refresh the cache
+	cacheTimeout time.Duration
+}
+
+func NewClient() *Client {
+	return &Client{
+		HttpClient:   http.Client{},
+		cacheTimeout: CacheTimeout,
+		baseURL:      SolanaEpochStatsAPI,
+	}
+}
+
+func (c *Client) GetMinRequiredVersion(ctx context.Context, cluster string) (string, error) {
+	// Check cache first
+	c.mu.RLock()
+	if !c.cache.lastCheck.IsZero() && time.Since(c.cache.lastCheck) < c.cacheTimeout {
+		version := c.cache.version
+		c.mu.RUnlock()
+		return version, nil
+	}
+	c.mu.RUnlock()
+
+	// Make API request
+	url := fmt.Sprintf("%s?cluster=%s&epoch=latest", c.baseURL, cluster)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch min required version: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var stats ValidatorEpochStats
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Validate the response
+	if stats.Stats.Config.MinVersion == "" {
+		return "", fmt.Errorf("min_version not found in response")
+	}
+
+	// Update cache
+	c.mu.Lock()
+	c.cache.version = stats.Stats.Config.MinVersion
+	c.cache.lastCheck = time.Now()
+	c.mu.Unlock()
+
+	return stats.Stats.Config.MinVersion, nil
+}

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_GetMinRequiredVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		cluster    string
+		mockJSON   string
+		wantErr    bool
+		wantErrMsg string
+		want       string
+	}{
+		{
+			name:    "valid mainnet response",
+			cluster: "mainnet-beta",
+			mockJSON: `{
+				"stats": {
+					"config": {
+						"min_version": "2.0.20"
+					}
+				}
+			}`,
+			want: "2.0.20",
+		},
+		{
+			name:    "valid testnet response",
+			cluster: "testnet",
+			mockJSON: `{
+				"stats": {
+					"config": {
+						"min_version": "2.1.6"
+					}
+				}
+			}`,
+			want: "2.1.6",
+		},
+		{
+			name:       "invalid json response",
+			cluster:    "mainnet-beta",
+			mockJSON:   `{"invalid": "json"`,
+			wantErr:    true,
+			wantErrMsg: "failed to decode response",
+		},
+		{
+			name:       "missing version in response",
+			cluster:    "mainnet-beta",
+			mockJSON:   `{"stats": {"config": {}}}`,
+			wantErr:    true,
+			wantErrMsg: "min_version not found in response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request
+				assert.Equal(t, "/api/validators/epoch-stats", r.URL.Path)
+				assert.Equal(t, tt.cluster, r.URL.Query().Get("cluster"))
+				assert.Equal(t, "latest", r.URL.Query().Get("epoch"))
+
+				// Send response
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tt.mockJSON))
+			}))
+			defer server.Close()
+
+			// Create client with test server URL
+			client := &Client{
+				HttpClient:   http.Client{},
+				baseURL:      server.URL + "/api/validators/epoch-stats",
+				cacheTimeout: time.Hour,
+			}
+
+			// Test GetMinRequiredVersion
+			got, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+
+			// Test caching
+			cachedVersion, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, cachedVersion)
+		})
+	}
+}

--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type MockClient struct {
+	*Client
+}
+
+func NewMockClient() *MockClient {
+	mock := &Client{
+		HttpClient:   http.Client{},
+		baseURL:      SolanaEpochStatsAPI,
+		cacheTimeout: CacheTimeout,
+	}
+	return &MockClient{
+		Client: mock,
+	}
+}
+
+func (m *MockClient) SetMinRequiredVersion(version string) {
+	m.cache.version = version
+	m.cache.lastCheck = time.Now()
+}
+
+func (m *MockClient) GetMinRequiredVersion(ctx context.Context, cluster string) (string, error) {
+	return m.cache.version, nil
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,0 +1,9 @@
+package api
+
+type ValidatorEpochStats struct {
+	Stats struct {
+		Config struct {
+			MinVersion string `json:"min_version"`
+		} `json:"config"`
+	} `json:"stats"`
+}

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -44,7 +44,26 @@ const (
 	CommitmentConfirmed Commitment = "confirmed"
 	// CommitmentProcessed level represents a transaction that has been received by the network and included in a block.
 	CommitmentProcessed Commitment = "processed"
+
+	// Genesis hashes for different Solana clusters
+	DevnetGenesisHash  = "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"
+	TestnetGenesisHash = "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY"
+	MainnetGenesisHash = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"
 )
+
+// getClusterFromGenesisHash returns the cluster name based on the genesis hash
+func GetClusterFromGenesisHash(hash string) (string, error) {
+	switch hash {
+	case DevnetGenesisHash:
+		return "devnet", nil
+	case TestnetGenesisHash:
+		return "testnet", nil
+	case MainnetGenesisHash:
+		return "mainnet-beta", nil
+	default:
+		return "", fmt.Errorf("unknown genesis hash: %s", hash)
+	}
+}
 
 func NewRPCClient(rpcAddr string, httpTimeout time.Duration) *Client {
 	return &Client{HttpClient: http.Client{}, RpcUrl: rpcAddr, HttpTimeout: httpTimeout, logger: slog.Get()}
@@ -269,6 +288,16 @@ func (c *Client) GetFirstAvailableBlock(ctx context.Context) (int64, error) {
 	var resp Response[int64]
 	if err := getResponse(ctx, c, "getFirstAvailableBlock", []any{}, &resp); err != nil {
 		return 0, err
+	}
+	return resp.Result, nil
+}
+
+// GetGenesisHash returns the hash of the genesis block
+// See API docs: https://solana.com/docs/rpc/http/getgenesishash
+func (c *Client) GetGenesisHash(ctx context.Context) (string, error) {
+	var resp Response[string]
+	if err := getResponse(ctx, c, "getGenesisHash", []any{}, &resp); err != nil {
+		return "", err
 	}
 	return resp.Result, nil
 }

--- a/pkg/rpc/mock.go
+++ b/pkg/rpc/mock.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/asymmetric-research/solana-exporter/pkg/slog"
-	"go.uber.org/zap"
 	"net"
 	"net/http"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/asymmetric-research/solana-exporter/pkg/slog"
+	"go.uber.org/zap"
 )
 
 type MockOpt int


### PR DESCRIPTION
## Summary
Add new metric `solana_min_required_version` to track the minimum required
Solana version for foundation delegation program across different clusters.

## Details
- New metric `solana_min_required_version` with version and cluster labels
- New `api` package to handle non-RPC API calls
- Caching mechanism to reduce API calls (6-hour cache)
- Automatic cluster detection using genesis hash

### Technical Details
- The metric queries https://api.solana.org/api/validators/epoch-stats to fetch the minimum version requirement
- Cluster is automatically determined from RPC endpoint's genesis hash:
  - Mainnet: 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
  - Testnet: 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY
  - Devnet: EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG
- API responses are cached for 6 hours to minimize external calls

### Testing
- Added unit tests for API client and caching behavior
- Added integration tests for metric collection
- Added mock clients for testing