### PR TITLE
fix rpc error unpacking in getHealth

### DIFF
--- a/cmd/solana-exporter/collector.go
+++ b/cmd/solana-exporter/collector.go
@@ -328,7 +328,7 @@ func (c *SolanaCollector) collectHealth(ctx context.Context, ch chan<- prometheu
 				ch <- c.NodeNumSlotsBehind.NewInvalidMetric(err)
 				return
 			}
-			if err = rpc.UnpackRpcErrorData(rpcError, errorData); err != nil {
+			if err = rpc.UnpackRpcErrorData(rpcError, &errorData); err != nil {
 				// if we error here, it means we have the incorrect format
 				c.logger.Fatalf("failed to unpack %s rpc error: %v", rpcError.Method, err.Error())
 			}


### PR DESCRIPTION
When reading the node health from the RPC and upon it returning an unhealthy error the error isn't unpacked correctly, resulting in solana-exporter to crash.