### PR TITLE
Test collect health

### DIFF
--- a/cmd/solana-exporter/collector_test.go
+++ b/cmd/solana-exporter/collector_test.go
@@ -64,6 +64,7 @@ func NewSimulator(t *testing.T, slot int) (*Simulator, *rpc.Client) {
 			"getLeaderSchedule": leaderSchedule,
 			"getHealth":         "ok",
 		},
+		nil,
 		map[string]int{
 			"aaa": 1 * rpc.LamportsInSol,
 			"bbb": 2 * rpc.LamportsInSol,

--- a/cmd/solana-exporter/collector_test.go
+++ b/cmd/solana-exporter/collector_test.go
@@ -321,7 +321,7 @@ func TestSolanaCollector_collectHealth(t *testing.T) {
 		}
 	})
 
-	getHealthErr := rpc.RPCError{
+	getHealthErr := rpc.Error{
 		Code:    rpc.NodeUnhealthyCode,
 		Method:  "getHealth",
 		Message: "Node is unhealthy",

--- a/cmd/solana-exporter/slots.go
+++ b/cmd/solana-exporter/slots.go
@@ -432,7 +432,7 @@ func (c *SlotWatcher) fetchAndEmitSingleBlockInfo(
 	}
 	block, err := c.client.GetBlock(ctx, rpc.CommitmentConfirmed, slot, transactionDetails)
 	if err != nil {
-		var rpcError *rpc.RPCError
+		var rpcError *rpc.Error
 		if errors.As(err, &rpcError) {
 			// this is the error code for slot was skipped:
 			if rpcError.Code == rpc.SlotSkippedCode && strings.Contains(rpcError.Message, "skipped") {

--- a/cmd/solana-exporter/utils.go
+++ b/cmd/solana-exporter/utils.go
@@ -234,6 +234,9 @@ func ExtractHealthAndNumSlotsBehind(health string, getHealthErr error) (bool, er
 	// see docs (https://solana.com/docs/rpc/http/gethealth)
 	if rpcError.Data == nil {
 		// this is the generic case:
+		// TODO: in this generic case, do we want to emit an error to the solana_node_num_slots_behind metric?
+		//  The node is definitely unhealthy, but we do not have the information to determine what numSlotsBehind is,
+		//  so do we say 0 or error?
 		return false, nil, 0, fmt.Errorf("unhealthy node but cannot determine numSlotsBehind: %w", getHealthErr)
 	}
 

--- a/cmd/solana-exporter/utils.go
+++ b/cmd/solana-exporter/utils.go
@@ -224,7 +224,7 @@ func ExtractHealthAndNumSlotsBehind(health string, getHealthErr error) (bool, er
 
 	// now from here on, we just have to handle the error, first check if it's some random error
 	// and not an unhealthy-node error:
-	var rpcError *rpc.RPCError
+	var rpcError *rpc.Error
 	if ok := errors.As(getHealthErr, &rpcError); !ok || rpcError.Code != rpc.NodeUnhealthyCode {
 		err := fmt.Errorf("failed to call getHealth: %w", getHealthErr)
 		return false, err, 0, err

--- a/cmd/solana-exporter/utils.go
+++ b/cmd/solana-exporter/utils.go
@@ -198,53 +198,56 @@ func BoolToFloat64(b bool) float64 {
 
 // ExtractHealthAndNumSlotsBehind takes the outputs from the GetHealth RPC method and determines the corresponding
 // health status and number of slots behind, along with potential errors corresponding to each metric
-func ExtractHealthAndNumSlotsBehind(health string, getHealthErr error) (bool, error, int64, error) {
-	// healthy node:
-	if health == "ok" {
-		// this is checking an edge case which is unexpected to happen; whenever we have "ok",
-		// we shouldn't be getting an error
-		if getHealthErr != nil {
+func ExtractHealthAndNumSlotsBehind(health string, getHealthErr error) (
+	isHealthy bool, isHealthyErr error, numSlotsBehind int64, numSlotsBehindErr error,
+) {
+	// for an unhealthy node:
+	if health != "ok" {
+		// first check this unexpected edge case: whenever we don't get "ok" from the
+		// health check, we should get an error
+		if getHealthErr == nil {
 			// if this happens, return and error for both values:
-			err := fmt.Errorf("health check returned 'ok' and error: %w", getHealthErr)
+			err := fmt.Errorf("health check did not return 'ok' (%s) but no error", health)
 			return false, err, 0, err
 		}
 
-		// in this expected case, we are healthy + no error:
-		return true, nil, 0, nil
+		// now from here on, we just have to handle the error, first check if it's some random error
+		// and not an unhealthy-node error:
+		var rpcError *rpc.Error
+		if ok := errors.As(getHealthErr, &rpcError); !ok || rpcError.Code != rpc.NodeUnhealthyCode {
+			err := fmt.Errorf("failed to call getHealth: %w", getHealthErr)
+			return false, err, 0, err
+		}
+
+		// from here, this must be a node-unhealthy error, so now we check if it's generic or not
+		// see docs (https://solana.com/docs/rpc/http/gethealth)
+		if rpcError.Data == nil {
+			// this is the generic case:
+			// TODO: in this generic case, do we want to emit an error to the solana_node_num_slots_behind metric?
+			//  The node is definitely unhealthy, but we do not have the information to determine what numSlotsBehind is,
+			//  so do we say 0 or error?
+			return false, nil, 0, fmt.Errorf("unhealthy node but cannot determine numSlotsBehind: %w", getHealthErr)
+		}
+
+		var errorData rpc.NodeUnhealthyErrorData
+		if err := rpc.UnpackRpcErrorData(rpcError, &errorData); err != nil {
+			// if we error here, it means we have the incorrect format:
+			return false, nil, 0, fmt.Errorf("failed to unpack RPC error data: %w", err)
+		}
+
+		// if it unpacked correctly, then just return the numSlotsBehind:
+		return false, nil, errorData.NumSlotsBehind, nil
 	}
 
-	// now for an unhealthy node, first check this unexpected edge case: whenever we don't get "ok" from the
-	// health check, we should get an error
-	if getHealthErr == nil {
+	// now for a healthy node, first check an edge case which is unexpected to happen; whenever we have "ok",
+	// we shouldn't be getting an error
+	if getHealthErr != nil {
 		// if this happens, return and error for both values:
-		err := fmt.Errorf("health check did not return 'ok' (%s) but no error", health)
+		err := fmt.Errorf("health check returned 'ok' and error: %w", getHealthErr)
 		return false, err, 0, err
 	}
 
-	// now from here on, we just have to handle the error, first check if it's some random error
-	// and not an unhealthy-node error:
-	var rpcError *rpc.Error
-	if ok := errors.As(getHealthErr, &rpcError); !ok || rpcError.Code != rpc.NodeUnhealthyCode {
-		err := fmt.Errorf("failed to call getHealth: %w", getHealthErr)
-		return false, err, 0, err
-	}
+	// in this expected case, we are healthy + no error:
+	return true, nil, 0, nil
 
-	// from here, this must be a node-unhealthy error, so now we check if it's generic or not
-	// see docs (https://solana.com/docs/rpc/http/gethealth)
-	if rpcError.Data == nil {
-		// this is the generic case:
-		// TODO: in this generic case, do we want to emit an error to the solana_node_num_slots_behind metric?
-		//  The node is definitely unhealthy, but we do not have the information to determine what numSlotsBehind is,
-		//  so do we say 0 or error?
-		return false, nil, 0, fmt.Errorf("unhealthy node but cannot determine numSlotsBehind: %w", getHealthErr)
-	}
-
-	var errorData rpc.NodeUnhealthyErrorData
-	if err := rpc.UnpackRpcErrorData(rpcError, &errorData); err != nil {
-		// if we error here, it means we have the incorrect format:
-		return false, nil, 0, fmt.Errorf("failed to unpack RPC error data: %w", err)
-	}
-
-	// if it unpacked correctly, then just return the numSlotsBehind:
-	return false, nil, errorData.NumSlotsBehind, nil
 }

--- a/cmd/solana-exporter/utils.go
+++ b/cmd/solana-exporter/utils.go
@@ -192,9 +192,8 @@ func CountVoteTransactions(block *rpc.Block) (int, error) {
 func BoolToFloat64(b bool) float64 {
 	if b {
 		return 1
-	} else {
-		return 0
 	}
+	return 0
 }
 
 // ExtractHealthAndNumSlotsBehind takes the outputs from the GetHealth RPC method and determines the corresponding

--- a/cmd/solana-exporter/utils_test.go
+++ b/cmd/solana-exporter/utils_test.go
@@ -35,7 +35,7 @@ func TestGetTrimmedLeaderSchedule(t *testing.T) {
 				"ccc": []int{2, 5, 8, 11, 14},
 			},
 		},
-		nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/solana-exporter/utils_test.go
+++ b/cmd/solana-exporter/utils_test.go
@@ -168,7 +168,7 @@ func TestExtractHealthAndNumSlotsBehind(t *testing.T) {
 	})
 
 	t.Run("unhealthy-node", func(t *testing.T) {
-		getHealthErr := rpc.RPCError{
+		getHealthErr := rpc.Error{
 			Code:    -32005,
 			Method:  "getHealth",
 			Message: "Node is unhealthy",

--- a/cmd/solana-exporter/utils_test.go
+++ b/cmd/solana-exporter/utils_test.go
@@ -152,3 +152,42 @@ func TestEpochTrackedValidators_AddTrackedValidators(t *testing.T) {
 		etv.trackedNodekeys,
 	)
 }
+
+func TestBoolToFloat64(t *testing.T) {
+	assert.Equal(t, float64(1), BoolToFloat64(true))
+	assert.Equal(t, float64(0), BoolToFloat64(false))
+}
+
+func TestExtractHealthAndNumSlotsBehind(t *testing.T) {
+	t.Run("healthy-node", func(t *testing.T) {
+		health, healthErr, slots, slotsErr := ExtractHealthAndNumSlotsBehind("ok", nil)
+		assert.Equal(t, true, health)
+		assert.NoError(t, healthErr)
+		assert.Equal(t, slots, int64(0))
+		assert.NoError(t, slotsErr)
+	})
+
+	t.Run("unhealthy-node", func(t *testing.T) {
+		getHealthErr := rpc.RPCError{
+			Code:    -32005,
+			Method:  "getHealth",
+			Message: "Node is unhealthy",
+		}
+		t.Run("generic", func(t *testing.T) {
+			health, healthErr, slots, slotsErr := ExtractHealthAndNumSlotsBehind("", &getHealthErr)
+			assert.Equal(t, false, health)
+			assert.NoError(t, healthErr)
+			assert.Equal(t, slots, int64(0))
+			assert.Error(t, slotsErr)
+		})
+
+		getHealthErr.Data = map[string]any{"numSlotsBehind": 42}
+		t.Run("specific", func(t *testing.T) {
+			health, healthErr, slots, slotsErr := ExtractHealthAndNumSlotsBehind("", &getHealthErr)
+			assert.Equal(t, false, health)
+			assert.NoError(t, healthErr)
+			assert.Equal(t, int64(42), slots)
+			assert.NoError(t, slotsErr)
+		})
+	})
+}

--- a/pkg/rpc/client_test.go
+++ b/pkg/rpc/client_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newMethodTester(t *testing.T, method string, result any, err *RPCError) (*MockServer, *Client) {
+func newMethodTester(t *testing.T, method string, result any, err *Error) (*MockServer, *Client) {
 	t.Helper()
-	errs := make(map[string]*RPCError)
+	errs := make(map[string]*Error)
 	if err != nil {
 		errs[method] = err
 	}
@@ -150,7 +150,7 @@ func TestClient_GetHealth(t *testing.T) {
 	})
 
 	t.Run("unhealthy-node", func(t *testing.T) {
-		unhealthyErr := RPCError{
+		unhealthyErr := Error{
 			Code:    NodeUnhealthyCode,
 			Message: "Node is unhealthy",
 			Method:  "getHealth",

--- a/pkg/rpc/client_test.go
+++ b/pkg/rpc/client_test.go
@@ -7,15 +7,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newMethodTester(t *testing.T, method string, result any) (*MockServer, *Client) {
+func newMethodTester(t *testing.T, method string, result any, err *RPCError) (*MockServer, *Client) {
 	t.Helper()
-	return NewMockClient(t, map[string]any{method: result}, nil, nil, nil, nil)
+	errs := make(map[string]*RPCError)
+	if err != nil {
+		errs[method] = err
+	}
+	return NewMockClient(t, map[string]any{method: result}, errs, nil, nil, nil, nil)
 }
 
 func TestClient_GetBalance(t *testing.T) {
 	_, client := newMethodTester(t,
 		"getBalance",
 		map[string]any{"context": map[string]int{"slot": 1}, "value": 5 * LamportsInSol},
+		nil,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -36,6 +41,7 @@ func TestClient_GetBlock(t *testing.T) {
 				{"transaction": {"message": {"accountKeys": {"aaa", "bbb", "ccc"}}}},
 			},
 		},
+		nil,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -74,6 +80,7 @@ func TestClient_GetBlockProduction(t *testing.T) {
 				},
 			},
 		},
+		nil,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -100,6 +107,7 @@ func TestClient_GetEpochInfo(t *testing.T) {
 			"slotsInEpoch":     8_192,
 			"transactionCount": 22_661_093,
 		},
+		nil,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -120,7 +128,7 @@ func TestClient_GetEpochInfo(t *testing.T) {
 }
 
 func TestClient_GetFirstAvailableBlock(t *testing.T) {
-	_, client := newMethodTester(t, "getFirstAvailableBlock", 250_000)
+	_, client := newMethodTester(t, "getFirstAvailableBlock", 250_000, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -130,13 +138,47 @@ func TestClient_GetFirstAvailableBlock(t *testing.T) {
 }
 
 func TestClient_GetHealth(t *testing.T) {
-	_, client := newMethodTester(t, "getHealth", "ok")
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// using example responses in the docs: https://solana.com/docs/rpc/http/gethealth
+	t.Run("healthy-node", func(t *testing.T) {
+		_, client := newMethodTester(t, "getHealth", "ok", nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	health, err := client.GetHealth(ctx)
-	assert.NoError(t, err)
-	assert.Equal(t, "ok", health)
+		health, err := client.GetHealth(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "ok", health)
+	})
+
+	t.Run("unhealthy-node", func(t *testing.T) {
+		unhealthyErr := RPCError{
+			Code:    NodeUnhealthyCode,
+			Message: "Node is unhealthy",
+			Method:  "getHealth",
+		}
+
+		t.Run("generic", func(t *testing.T) {
+			_, client := newMethodTester(t, "getHealth", nil, &unhealthyErr)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			health, err := client.GetHealth(ctx)
+			assert.Equal(t, health, "")
+			assert.Equal(t, &unhealthyErr, err)
+		})
+
+		unhealthyErr.Data = map[string]any{"numSlotsBehind": float64(42)}
+
+		t.Run("specific", func(t *testing.T) {
+			_, client := newMethodTester(t, "getHealth", nil, &unhealthyErr)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			health, err := client.GetHealth(ctx)
+			assert.Equal(t, health, "")
+			assert.Equal(t, &unhealthyErr, err)
+		})
+
+	})
 }
 
 func TestClient_GetInflationReward(t *testing.T) {
@@ -150,6 +192,7 @@ func TestClient_GetInflationReward(t *testing.T) {
 				"postBalance":   499_999_442_500,
 			},
 		},
+		nil,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -168,7 +211,7 @@ func TestClient_GetLeaderSchedule(t *testing.T) {
 		"bbb": {5, 6, 7, 8, 9},
 		"ccc": {10, 11, 12, 13, 14},
 	}
-	_, client := newMethodTester(t, "getLeaderSchedule", expectedSchedule)
+	_, client := newMethodTester(t, "getLeaderSchedule", expectedSchedule, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -178,7 +221,7 @@ func TestClient_GetLeaderSchedule(t *testing.T) {
 }
 
 func TestClient_GetMinimumLedgerSlot(t *testing.T) {
-	_, client := newMethodTester(t, "minimumLedgerSlot", 250)
+	_, client := newMethodTester(t, "minimumLedgerSlot", 250, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -188,7 +231,7 @@ func TestClient_GetMinimumLedgerSlot(t *testing.T) {
 }
 
 func TestClient_GetSlot(t *testing.T) {
-	_, client := newMethodTester(t, "getSlot", 1234)
+	_, client := newMethodTester(t, "getSlot", 1234, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -199,7 +242,7 @@ func TestClient_GetSlot(t *testing.T) {
 
 func TestClient_GetVersion(t *testing.T) {
 	expectedResult := map[string]any{"feature-set": 2891131721, "solana-core": "1.16.7"}
-	_, client := newMethodTester(t, "getVersion", expectedResult)
+	_, client := newMethodTester(t, "getVersion", expectedResult, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -225,6 +268,7 @@ func TestClient_GetVoteAccounts(t *testing.T) {
 			},
 			"delinquent": nil,
 		},
+		nil,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -247,9 +291,10 @@ func TestClient_GetVoteAccounts(t *testing.T) {
 }
 
 func TestClient_GetIdentity(t *testing.T) {
-	_, client := newMethodTester(t, "getIdentity", map[string]string{
-		"identity": "random2r1F4iWqVcb8M1DbAjQuFpebkQuW2DJtestkey",
-	})
+	_, client := newMethodTester(t,
+		"getIdentity", map[string]string{"identity": "random2r1F4iWqVcb8M1DbAjQuFpebkQuW2DJtestkey"},
+		nil,
+	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/rpc/errors.go
+++ b/pkg/rpc/errors.go
@@ -33,7 +33,7 @@ type (
 	}
 )
 
-func UnpackRpcErrorData[T any](rpcErr *RPCError, formatted T) error {
+func UnpackRpcErrorData[T any](rpcErr *Error, formatted T) error {
 	bytesData, err := json.Marshal(rpcErr.Data)
 	if err != nil {
 		return fmt.Errorf("failed to marshal %s rpc-error data: %w", rpcErr.Method, err)

--- a/pkg/rpc/mock.go
+++ b/pkg/rpc/mock.go
@@ -22,6 +22,7 @@ const (
 	EasyResultsOpt
 	SlotInfosOpt
 	ValidatorInfoOpt
+	EasyErrorsOpt = 5
 )
 
 type (
@@ -144,6 +145,12 @@ func (s *MockServer) SetOpt(opt MockOpt, key any, value any) {
 			s.validatorInfos = make(map[string]MockValidatorInfo)
 		}
 		s.validatorInfos[key.(string)] = value.(MockValidatorInfo)
+	case EasyErrorsOpt:
+		if s.easyErrors == nil {
+			s.easyErrors = make(map[string]*RPCError)
+		}
+		err := value.(RPCError)
+		s.easyErrors[key.(string)] = &err
 	}
 }
 

--- a/pkg/rpc/mock.go
+++ b/pkg/rpc/mock.go
@@ -36,7 +36,7 @@ type (
 		balances         map[string]int
 		inflationRewards map[string]int
 		easyResults      map[string]any
-		easyErrors       map[string]*RPCError
+		easyErrors       map[string]*Error
 
 		SlotInfos      map[int]MockSlotInfo
 		validatorInfos map[string]MockValidatorInfo
@@ -64,7 +64,7 @@ type (
 // NewMockServer creates a new mock server instance
 func NewMockServer(
 	easyResults map[string]any,
-	easyErrors map[string]*RPCError,
+	easyErrors map[string]*Error,
 	balances map[string]int,
 	inflationRewards map[string]int,
 	slotInfos map[int]MockSlotInfo,
@@ -147,9 +147,9 @@ func (s *MockServer) SetOpt(opt MockOpt, key any, value any) {
 		s.validatorInfos[key.(string)] = value.(MockValidatorInfo)
 	case EasyErrorsOpt:
 		if s.easyErrors == nil {
-			s.easyErrors = make(map[string]*RPCError)
+			s.easyErrors = make(map[string]*Error)
 		}
-		err := value.(RPCError)
+		err := value.(Error)
 		s.easyErrors[key.(string)] = &err
 	}
 }
@@ -160,7 +160,7 @@ func (s *MockServer) GetValidatorInfo(nodekey string) MockValidatorInfo {
 	return s.validatorInfos[nodekey]
 }
 
-func (s *MockServer) getResult(method string, params ...any) (any, *RPCError) {
+func (s *MockServer) getResult(method string, params ...any) (any, *Error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -200,10 +200,10 @@ func (s *MockServer) getResult(method string, params ...any) (any, *RPCError) {
 		slotInfo, ok := s.SlotInfos[slot]
 		if !ok {
 			s.logger.Warnf("no slot info for slot %d", slot)
-			return nil, &RPCError{Code: BlockCleanedUpCode, Message: "Block cleaned up."}
+			return nil, &Error{Code: BlockCleanedUpCode, Message: "Block cleaned up."}
 		}
 		if slotInfo.Block == nil {
-			return nil, &RPCError{Code: SlotSkippedCode, Message: "Slot skipped."}
+			return nil, &Error{Code: SlotSkippedCode, Message: "Slot skipped."}
 		}
 		var (
 			transactions []map[string]any
@@ -281,7 +281,7 @@ func (s *MockServer) getResult(method string, params ...any) (any, *RPCError) {
 	// default is use easy results:
 	result, ok := s.easyResults[method]
 	if !ok {
-		return nil, &RPCError{Code: -32601, Message: "Method not found"}
+		return nil, &Error{Code: -32601, Message: "Method not found"}
 	}
 	return result, nil
 }
@@ -317,7 +317,7 @@ func (s *MockServer) handleRPCRequest(w http.ResponseWriter, r *http.Request) {
 func NewMockClient(
 	t *testing.T,
 	easyResults map[string]any,
-	easyErrors map[string]*RPCError,
+	easyErrors map[string]*Error,
 	balances map[string]int,
 	inflationRewards map[string]int,
 	slotInfos map[int]MockSlotInfo,

--- a/pkg/rpc/mock_test.go
+++ b/pkg/rpc/mock_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMockServer_getBalance(t *testing.T) {
 	_, client := NewMockClient(
-		t, nil, map[string]int{"aaa": 2 * LamportsInSol}, nil, nil, nil,
+		t, nil, nil, map[string]int{"aaa": 2 * LamportsInSol}, nil, nil, nil,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -21,6 +21,7 @@ func TestMockServer_getBalance(t *testing.T) {
 
 func TestMockServer_getBlock(t *testing.T) {
 	_, client := NewMockClient(t,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -63,6 +64,7 @@ func TestMockServer_getBlockProduction(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		map[int]MockSlotInfo{
 			1: {"aaa", &MockBlockInfo{}},
 			2: {"aaa", &MockBlockInfo{}},
@@ -98,6 +100,7 @@ func TestMockServer_getInflationReward(t *testing.T) {
 	_, client := NewMockClient(t,
 		nil,
 		nil,
+		nil,
 		map[string]int{"AAA": 2_500, "BBB": 2_501, "CCC": 2_502},
 		nil,
 		nil,
@@ -116,6 +119,7 @@ func TestMockServer_getInflationReward(t *testing.T) {
 
 func TestMockServer_getVoteAccounts(t *testing.T) {
 	_, client := NewMockClient(t,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/pkg/rpc/responses.go
+++ b/pkg/rpc/responses.go
@@ -6,7 +6,7 @@ import (
 )
 
 type (
-	RPCError struct {
+	Error struct {
 		Message string         `json:"message"`
 		Code    int64          `json:"code"`
 		Data    map[string]any `json:"data"`
@@ -16,9 +16,9 @@ type (
 
 	Response[T any] struct {
 		Jsonrpc string   `json:"jsonrpc"`
-		Result  T        `json:"result,omitempty"`
-		Error   RPCError `json:"error,omitempty"`
-		Id      int      `json:"id"`
+		Result T     `json:"result,omitempty"`
+		Error  Error `json:"error,omitempty"`
+		Id     int   `json:"id"`
 	}
 
 	contextualResult[T any] struct {
@@ -90,7 +90,7 @@ type (
 	}
 )
 
-func (e *RPCError) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("%s rpc error (code: %d): %s (data: %v)", e.Method, e.Code, e.Message, e.Data)
 }
 

--- a/pkg/rpc/responses.go
+++ b/pkg/rpc/responses.go
@@ -15,10 +15,10 @@ type (
 	}
 
 	Response[T any] struct {
-		Jsonrpc string   `json:"jsonrpc"`
-		Result T     `json:"result,omitempty"`
-		Error  Error `json:"error,omitempty"`
-		Id     int   `json:"id"`
+		Jsonrpc string `json:"jsonrpc"`
+		Result  T      `json:"result,omitempty"`
+		Error   Error  `json:"error,omitempty"`
+		Id      int    `json:"id"`
 	}
 
 	contextualResult[T any] struct {


### PR DESCRIPTION
Added tests for the `collectHealth` function. This involved some extra steps:
* Making it easy to return errors using the mock client/server.
* Refactoring `collectHealth` to a separate `ExtractHealthAndNumSlotsBehind` function which contains the bulk of the logic.
* Adding the actual tests.

Most of the tests are written using the cases provided in the [RPC docs](https://solana.com/docs/rpc/http/gethealth).

ALSO, I renamed `rpc.RPCError` -> `rpc.Error` :) 